### PR TITLE
adding support for training just with MLP

### DIFF
--- a/examples/shortest_path/dataGen.py
+++ b/examples/shortest_path/dataGen.py
@@ -74,12 +74,16 @@ def generateDataset(inPath, outPath):
 dataset = generateDataset('data/shortestPath.data', 'data/shorteatPath_')
 
 # for training
+training_just_with_labels = False
 obsList = []
 with open('data/shorteatPath_train.txt', 'r') as f:
     obsList = f.read().strip().strip('#evidence').split('#evidence')
 dataList = []
-for data in dataset['train']:
-    dataList.append({'g': Variable(torch.from_numpy(data).float(), requires_grad=False)})
+for data, label in zip(dataset['train'], dataset['train_label']):
+    if training_just_with_labels:
+        dataList.append({'g': (Variable(torch.from_numpy(data).float(), requires_grad=False), {'sp': Variable(torch.from_numpy(label).float().view(-1, 1), requires_grad=False)})})
+    else:
+        dataList.append({'g': Variable(torch.from_numpy(data).float(), requires_grad=False)})
 
 # for testing
 obsListTest = []

--- a/examples/shortest_path/train.py
+++ b/examples/shortest_path/train.py
@@ -115,6 +115,8 @@ for i in range(50):
     print('Continuously training for 10 epochs round {}...'.format(i+1))
     time1 = time.time()
     NeurASPobj.learn(dataList=dataList, obsList=obsList, epoch=10, opt=True, smPickle='data/stableModels.pickle', bar=True)
+    # If training MLP with just labels, use this line instead of above. Also change training_just_with_labels to True in dataGen.py
+    # NeurASPobj.learn(dataList=dataList, obsList=obsList, epoch=10, opt=True, smPickle='data/stableModels.pickle', bar=True, alpha=1, lossFunc=torch.nn.BCELoss())
     time2 = time.time()
     NeurASPobj.testConstraint(dataList=dataListTest, obsList=obsListTest, mvppList=combinations)
     print("--- train time: %s seconds ---" % (time2 - time1))


### PR DESCRIPTION
Two changes are added:
1. dataGen.py: When training_just_with_labels = True, it will add labels with right format for training the network with just labels.
2. train.py: A commented example for training with just labels is added.